### PR TITLE
Upgrade GitHub actions versions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,7 +18,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
 

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -28,16 +28,16 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'npm'
           cache-dependency-path: .lib/package-lock.json
-  
+
       - name: Make install
         run: make install
 
       - name: Get changed files
         id: changed-parser
-        uses: tj-actions/changed-files@v11.7
+        uses: tj-actions/changed-files@v35
         with:
           files: |
-            \.js$
+            **/*.js
 
       - name: Run lint test
         shell: bash

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -23,7 +23,7 @@ jobs:
           fetch-depth: 0
 
       - name: Use Node.js ${{ env.NODE_VERSION }}
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'npm'

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,7 +27,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           fetch-depth: 0
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -43,10 +43,10 @@ jobs:
 
       - name: Get changed files
         id: changed-parser
-        uses: tj-actions/changed-files@v11.7
+        uses: tj-actions/changed-files@v35
         with:
           files: |
-            \.js$
+            **/*.js
           files_ignore: .lib/**
 
       - name: Run mocha tests

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,7 +32,7 @@ jobs:
           fetch-depth: 0
 
       - name: Use Node.js ${{ env.NODE_VERSION }}
-        uses: actions/setup-node@v2
+        uses: actions/setup-node@v3
         with:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'npm'


### PR DESCRIPTION
Should fix warnings when action is running

## Updated actions

- [run-linter](https://github.com/ezpaarse-project/ezpaarse-platforms/blob/a8b0a694528f1cbdcedc8d4cd1d798bc87baed63/.github/workflows/lint.yml) (`lint.yml`)
  - [actions/checkout](https://github.com/actions/checkout) (v2 -> v3)
  - [actions/setup-node](https://github.com/actions/setup-node) (v2 -> v3)
  - [tj-actions/changed-files](https://github.com/tj-actions/changed-files) (v11 -> v35)
- [run-tests](https://github.com/ezpaarse-project/ezpaarse-platforms/blob/a8b0a694528f1cbdcedc8d4cd1d798bc87baed63/.github/workflows/tests.yml) (`tests.yml`)
  - [actions/checkout](https://github.com/actions/checkout) (v2 -> v3)
  - [actions/setup-node](https://github.com/actions/setup-node) (v2 -> v3)
  - [tj-actions/changed-files](https://github.com/tj-actions/changed-files) (v11 -> v35)

## Notable changes

- `files` parameter of [tj-actions/changed-files](https://github.com/tj-actions/changed-files) is now a [glob pattern](https://en.wikipedia.org/wiki/Glob_(programming)) instead of a regex