### PR TITLE
NCBI Parser Updates

### DIFF
--- a/ncbi/parser.js
+++ b/ncbi/parser.js
@@ -34,8 +34,14 @@ module.exports = new Parser(function analyseEC(parsedUrl, ec) {
   } else if ((match = /^\/([a-z]+)\/([a-z0-9]+)\/?$/i.exec(path)) !== null) {
     // /pubmed/28750474
     // /books/NBK435759/
+    // /sites/PubmedCitation?id=32661314&_=1638133014618
+    // /nlmcatalog/255562
 
-    if (!/^[a-z]+$/.test(match[2])) {
+    if (/^(sites|nlmcatalog)$/.test(match[1])) {
+      result.mime = match[1] === 'nlmcatalog' ? 'HTML' : 'XML';
+      result.rtype = 'CITATION';
+    }
+    else if (/^(books|pubmed)$/.test(match[1])) {
       result.mime   = 'HTML';
       result.rtype  = match[1] === 'books' ? 'BOOK_SECTION' : 'ABS';
       result.unitid = match[2];

--- a/ncbi/test/NCBI.2023-06-28.csv
+++ b/ncbi/test/NCBI.2023-06-28.csv
@@ -1,0 +1,7 @@
+out-title_id;out-unitid;out-rtype;out-mime;in-url
+;;;;https://www.ncbi.nlm.nih.gov/biosample/SAMN16556596
+;;SEARCH;HTML;https://www.ncbi.nlm.nih.gov/biosample/?term=%22pathogen%20cl%201%200%22[filter]
+;;CITATION;XML;https://www.ncbi.nlm.nih.gov/sites/PubmedCitation?id=32661314&_=1638133014618
+;;SEARCH;HTML;https://www.ncbi.nlm.nih.gov/nlmcatalog?term=%22Prog+Polym+Sci%22%5BTitle+Abbreviation%5D
+;;CITATION;HTML;https://www.ncbi.nlm.nih.gov/nlmcatalog/255562
+;PMC4981537;ARTICLE;HTML;https://www.ncbi.nlm.nih.gov/pmc/articles/PMC4981537/


### PR DESCRIPTION
Updates to NCBI parser to extract the pubmed, pubmed Central and book ids.  This commit will keep the records of searches for genes and proteins, but not save them as a publication id.

A new middleware to enrich the NCBI records via the NCBI API will be added which relies (somewhat) on this pull request.