### PR TITLE
Update manifest.json

### DIFF
--- a/kanopy-2018/manifest.json
+++ b/kanopy-2018/manifest.json
@@ -12,7 +12,8 @@
       "emory.kanopystreaming.com",
       "umb.kanopy.com",
       "help.kanopystreaming.com",
-      "laney.kanopystreaming.com"
+      "laney.kanopystreaming.com",
+      "qub.kanopystreaming.com"
 	],
   "pkb": false
 }


### PR DESCRIPTION
Added qub.kanopystreaming.com.  Confirmed Queen's University Belfast uses older link.