### PR TITLE
filtering special ezPAARSE User-Agent (both normal and anonymized version)

### DIFF
--- a/thesesfr/parser.js
+++ b/thesesfr/parser.js
@@ -44,7 +44,10 @@ module.exports = new Parser(function analyseEC(parsedUrl, ec) {
 
   let match;
 
-  if (ec['User-Agent'] === 'node') {
+  const userAgentezPAARSE = 'ezPAARSE (https://readmetrics.org; mailto:ezteam@couperin.org)';
+  const userAgentezPAARSEAnon = 'ezPAARSE (https://readmetrics.org; mailto:)';
+
+  if ((ec['User-Agent'] === 'node') || (ec['User-Agent'] === userAgentezPAARSE) || (ec['User-Agent'] === userAgentezPAARSEAnon)) {
     //NOP
 
   } else if (


### PR DESCRIPTION
we are tagging HTTP calls to theses.fr API from middleware code with a special User-Agent string 'ezPAARSE (https://readmetrics.org/; mailto:ezteam@couperin.org)' so we can skip middleware calls next time we parse Apache logs