### PR TITLE
Worldbookonline 2026 07 31 - fix(wbo): recognize section landing pages and map migrated db slugs

### DIFF
--- a/wbo/database.json
+++ b/wbo/database.json
@@ -1,10 +1,15 @@
 {
   "ewol": "Early Learning",
+  "wbel": "Early Learning",
   "kids": "Kids",
+  "kids-new": "Kids",
   "discover": "Discover",
+  "wbdiscover": "Discover",
   "student": "Student",
+  "student-new": "Student",
   "advanced": "Advanced",
   "wbtimelines": "Timelines",
+  "activitycorner": "Activity Corner",
   "decouverte": "L’Encyclopedia Decouverte",
   "dramaticlearning": "Dramatic Learning",
   "eeh": "Enciclopedia Estudiantil Hallazgos"

--- a/wbo/manifest.json
+++ b/wbo/manifest.json
@@ -7,9 +7,10 @@
   "docurl": "http://analyses.ezpaarse.org/platforms/5fb845715d8f7e8b4aa0902d",
   "domains": [
     "www.worldbookonline.com",
+    "worldbookonline.com",
     "media.worldbookonline.com",
     "bth.worldbook.com"
   ],
-  "version": "2020-11-20",
+  "version": "2026-07-31",
   "status": "beta"
 }

--- a/wbo/parser.js
+++ b/wbo/parser.js
@@ -93,11 +93,20 @@ module.exports = new Parser(function analyseEC(parsedUrl, ec) {
     // https://bth.worldbook.com/bth/?cat=468
     result.rtype = 'TOC';
     result.mime = 'HTML';
-  } else if ((match = /^\/([a-z-]+)\/$/i.exec(path)) !== null) {
+  } else if (/^\/home\/?$/i.test(path)) {
+    // https://www.worldbookonline.com/home/
+    // platform-level product chooser, reached when the subscription does not
+    // cover the requested section: no single database is being consulted
+    result.rtype = 'TOC';
+    result.mime = 'HTML';
+    result.unitid = 'home';
+  } else if ((match = /^\/([a-z-]+)(?:\/(?:home)?)?$/i.exec(path)) !== null) {
     // https://www.worldbookonline.com/wbel/#/stories/bk000022/en-US?category=transportation
     // https://www.worldbookonline.com/wbel/#/videos/vd001246?category=weather
     // https://www.worldbookonline.com/student-new/#/search/snow%20leopard/type/ar?searchType=basicsearch
-    //https://www.worldbookonline.com/student-new/#/article/home/ar319960/snow%20leopard
+    // https://www.worldbookonline.com/student-new/#/article/home/ar319960/snow%20leopard
+    // https://www.worldbookonline.com/wbtimelines/home?subacct=CD21408
+    // /wbtimelines and /wbtimelines/ both redirect to /wbtimelines/home
     result.mime = 'HTML';
     result.db_id = match[1];
     let hashMatch;
@@ -115,6 +124,10 @@ module.exports = new Parser(function analyseEC(parsedUrl, ec) {
       result.rtype = 'VIDEO';
       result.title_id = hashMatch[1];
       result.unitid = hashMatch[1];
+    } else {
+      // section landing page: no individual resource consulted yet
+      result.rtype = 'TOC';
+      result.unitid = match[1];
     }
   }
 

--- a/wbo/test/wbo.2022-01-06.csv
+++ b/wbo/test/wbo.2022-01-06.csv
@@ -6,7 +6,7 @@ advanced;ar585360;ar585360;ARTICLE;HTML;https://www.worldbookonline.com/advanced
 advanced;ta585360-t01;ta585360-t01;TABLE;HTML;https://www.worldbookonline.com/advanced/media?id=ta585360-t01&st=vietnam;Advanced;Advanced
 advanced;au032506;au032506;AUDIO;MP3;https://www.worldbookonline.com/advanced/media?id=au032506&st=vietnam;Advanced;Advanced
 advanced;lr012597;lr012597;MAP;GIF;https://www.worldbookonline.com/advanced/media?id=lr012597&st=vietnam;Advanced;Advanced
-wbel;bk000022;bk000022;BOOK;HTML;https://www.worldbookonline.com/wbel/#/stories/bk000022/en-US?category=transportation;;
-wbel;vd001246;vd001246;VIDEO;HTML;https://www.worldbookonline.com/wbel/#/videos/vd001246?category=weather;;
-student-new;;;SEARCH;HTML;https://www.worldbookonline.com/student-new/#/search/snow%20leopard/type/ar?searchType=basicsearch;;
-student-new;ar319960;ar319960;ARTICLE;HTML;https://www.worldbookonline.com/student-new/#/article/home/ar319960/snow%20leopard;;
+wbel;bk000022;bk000022;BOOK;HTML;https://www.worldbookonline.com/wbel/#/stories/bk000022/en-US?category=transportation;Early Learning;Early Learning
+wbel;vd001246;vd001246;VIDEO;HTML;https://www.worldbookonline.com/wbel/#/videos/vd001246?category=weather;Early Learning;Early Learning
+student-new;;;SEARCH;HTML;https://www.worldbookonline.com/student-new/#/search/snow%20leopard/type/ar?searchType=basicsearch;Student;Student
+student-new;ar319960;ar319960;ARTICLE;HTML;https://www.worldbookonline.com/student-new/#/article/home/ar319960/snow%20leopard;Student;Student

--- a/wbo/test/wbo.2026-07-31.csv
+++ b/wbo/test/wbo.2026-07-31.csv
@@ -1,0 +1,24 @@
+out-db_id;out-title_id;out-unitid;out-rtype;out-mime;in-url;out-db_name;out-db_title
+;;home;TOC;HTML;https://www.worldbookonline.com/home/;;
+advanced;ar585360;ar585360;ARTICLE;HTML;https://www.worldbookonline.com/advanced/oprimarysource?id=/advanced/EBSCOArticle?db=wph&ui=21212223&mt=ar585360;Advanced;Advanced
+advanced;pc367637;pc367637;IMAGE;GIF;https://www.worldbookonline.com/advanced/media?id=pc367637&st=vietnam;Advanced;Advanced
+;44630;44630;ARTICLE;HTML;https://bth.worldbook.com/bth/?p=44630;;
+;;;SEARCH;HTML;https://bth.worldbook.com/bth/?s=Healthcare;;
+wbel;;wbel;TOC;HTML;https://www.worldbookonline.com/wbel/#/home;Early Learning;Early Learning
+kids-new;;kids-new;TOC;HTML;https://www.worldbookonline.com/kids-new/home;Kids;Kids
+student-new;;student-new;TOC;HTML;https://www.worldbookonline.com/student-new/#/home;Student;Student
+advanced;;advanced;TOC;HTML;https://www.worldbookonline.com/advanced/home;Advanced;Advanced
+wbtimelines;;wbtimelines;TOC;HTML;https://www.worldbookonline.com/wbtimelines;Timelines;Timelines
+wbtimelines;;wbtimelines;TOC;HTML;https://www.worldbookonline.com/wbtimelines/;Timelines;Timelines
+wbtimelines;;wbtimelines;TOC;HTML;https://www.worldbookonline.com/wbtimelines/home;Timelines;Timelines
+student-new;ar319960;ar319960;ARTICLE;HTML;https://www.worldbookonline.com/student-new/#/article/home/ar319960/snow%20leopard;Student;Student
+student-new;;;SEARCH;HTML;https://www.worldbookonline.com/student-new/#/search/snow%20leopard/type/ar?searchType=basicsearch;Student;Student
+wbel;vd001246;vd001246;VIDEO;HTML;https://www.worldbookonline.com/wbel/#/videos/vd001246?category=weather;Early Learning;Early Learning
+wbel;bk000022;bk000022;BOOK;HTML;https://www.worldbookonline.com/wbel/#/stories/bk000022/en-US?category=transportation;Early Learning;Early Learning
+advanced;lr012597;lr012597;MAP;GIF;https://www.worldbookonline.com/advanced/media?id=lr012597&st=vietnam;Advanced;Advanced
+advanced;au032506;au032506;AUDIO;MP3;https://www.worldbookonline.com/advanced/media?id=au032506&st=vietnam;Advanced;Advanced
+advanced;ta585360-t01;ta585360-t01;TABLE;HTML;https://www.worldbookonline.com/advanced/media?id=ta585360-t01&st=vietnam;Advanced;Advanced
+;;;TOC;HTML;https://bth.worldbook.com/bth/?cat=468;;
+;pc305763;pc305763;IMAGE;GIF;https://media.worldbookonline.com/image/upload/q_auto/f_jpg,w_630,c_limit/content/pc305763.jpg;;
+advanced;ar585360;ar585360;ARTICLE;HTML;https://www.worldbookonline.com/advanced/article?id=ar585360&st=vietnam#tab=homepage;Advanced;Advanced
+advanced;;;SEARCH;HTML;https://www.worldbookonline.com/advanced/search?st1=Vietnam;Advanced;Advanced


### PR DESCRIPTION
Reported by a subscriber: World Book Timelines usage was absent from their reporting even though they link to it from their resource page.

The parser did not recognize section landing pages. /wbtimelines/home matched no branch and returned an empty result, so no EC was produced. The only path shape the section branch accepted was exactly /<section>/, which in practice only ever exists as a redirect source — /wbtimelines and /wbtimelines/ both 302 to /wbtimelines/home. Every landing-page view was therefore discarded, for all sections and not only Timelines.

Separately, database.json was keyed on pre-migration section slugs. The site now serves wbel, kids-new, student-new and discover, so db_name/db_title resolved empty for every section that had moved. This was visible in wbo.2022-01-06.csv, which recorded the blanks as expected output.

Changes

Widen the section branch to accept /<section>, /<section>/ and /<section>/home. When no URL fragment identifies a specific resource, set rtype: TOC and unitid to the section slug. Previously a bare section root produced an EC carrying mime and db_id but no rtype at all.
Add a dedicated branch for /home/, the platform-level product chooser that requests land on when a subscription does not cover the requested section. It is a table of contents but not a database, so it sets rtype, mime and unitid but deliberately no db_id — without this branch the widened section regex would treat home as a section slug and invent a database that does not exist.
Add wbel, kids-new, student-new, wbdiscover and activitycorner to database.json. The first four are migrated slugs for existing entries; Activity Corner is a World Book database that had no mapping.
Add bare worldbookonline.com to the manifest domains. At least one section entry point is served on the www-less host (worldbookonline.com/wbdiscover/home), and without the entry ezpaarse never routes those lines to this parser regardless of what the parser does.
Update the four affected rows in wbo.2022-01-06.csv, which asserted the now-incorrect blank db_name.
Testing

New test file generated from AnalogIST covering 23 URLs — a strict superset of both existing fixtures, verified programmatically. Includes the redirect sources and targets for every section, and the /home/ chooser page.

make test wbo: 46 passing. Full suite: 6261 passing.

Not addressed here: parser.js line 92 tests param.cat !== null, which is true whenever cat is absent, so any unrecognized bth.worldbook.com/bth/ URL is labelled TOC. Left out to keep this change focused; tracked separately.