### PR TITLE
fix(clickview): capitalize longname to ClickView

### DIFF
--- a/clickview/manifest.json
+++ b/clickview/manifest.json
@@ -1,13 +1,13 @@
 {
-  "longname": "clickview",
+  "longname": "ClickView",
   "name": "clickview",
-  "describe": "Recognizes the accesses to the platform clickview",
+  "describe": "Recognizes the accesses to the platform ClickView",
   "contact": "Violita Kovchegov",
   "pkb": false,
   "docurl": "https://analyses.ezpaarse.org/platforms/6a33463f119cc74b49dd4905",
   "domains": [
     "www.clickview.net"
   ],
-  "version": "2026-06-17",
+  "version": "2026-07-30",
   "status": "beta"
 }


### PR DESCRIPTION
platform_name in ezPAARSE output is populated from the manifest's longname, which was lowercase clickview. A customer reported platform_name appearing as clickview rather than the correct vendor capitalization, ClickView.

This change:

Capitalizes longname to ClickView
Updates describe for consistency
Bumps the manifest version to 2026-07-30

The name field intentionally remains lowercase because it is the platform slug and must match the directory name.

The ClickView platform tests passed with 9 assertions. parser.js and the test CSV are unchanged.