### PR TITLE
4cn: fix BOOK detection for /shelf2/ and directories containing digits, expose title_id

### DIFF
--- a/4cn/manifest.json
+++ b/4cn/manifest.json
@@ -2,7 +2,7 @@
   "longname": "4 Canoes",
   "name": "4cn",
   "describe": "Recognizes the accesses to the platform 4 Canoes",
-  "contact": "Sean Duffy",
+  "contact": "Violita Kovchegov",
   "pkb": false,
   "docurl": "http://analyses.ezpaarse.org/platforms/617010a107376d3e3f4389b1",
   "domains": [
@@ -10,6 +10,6 @@
     "4canoes.org",
     "4canoesportal.org"
   ],
-  "version": "2021-10-23",
+  "version": "2026-08-17",
   "status": "beta"
 }

--- a/4cn/parser.js
+++ b/4cn/parser.js
@@ -20,11 +20,15 @@ module.exports = new Parser(function analyseEC(parsedUrl, ec) {
   // console.error(parsedUrl);
   let match;
 
-  if ((match = /^\/shelf\/[a-z-]+\/([a-z0-9-_]+)\.html$/i.exec(path)) !== null) {
+  if ((match = /^\/shelf\d*\/([a-z0-9-_]+)\/([a-z0-9-_]+)\.html$/i.exec(path)) !== null) {
     //https://4canoesportal.org/shelf/Haida/TheHaidaofHaidaGwaii_2022-11-07_15-24-05.html
+    //https://4canoesportal.org/shelf2/MikmaqSpecialEdition/MikmaqSpecialEdition_2025-11-19_15-39-21.html
     result.rtype = 'BOOK';
     result.mime = 'HTML';
-    result.unitid = match[1];
+    // the shelf directory identifies the title and is stable, while the file name
+    // carries a publication timestamp that changes each time a title is re-published
+    result.title_id = match[1];
+    result.unitid = match[2];
   } else if (/^\/([a-z-]+)\/?$/i.test(path)) {
     // https://4canoes.com/focused-education-resources
     result.rtype = 'QUERY';

--- a/4cn/test/4cn.2023-04-06.csv
+++ b/4cn/test/4cn.2023-04-06.csv
@@ -1,4 +1,4 @@
-out-unitid;out-rtype;out-mime;in-url
-TheHaidaofHaidaGwaii_2022-11-07_15-24-05;BOOK;HTML;https://4canoesportal.org/shelf/Haida/TheHaidaofHaidaGwaii_2022-11-07_15-24-05.html
-;QUERY;HTML;https://4canoesportal.org/focused/
-;QUERY;HTML;https://4canoes.com/focused-education-resources
+out-title_id;out-unitid;out-rtype;out-mime;in-url
+Haida;TheHaidaofHaidaGwaii_2022-11-07_15-24-05;BOOK;HTML;https://4canoesportal.org/shelf/Haida/TheHaidaofHaidaGwaii_2022-11-07_15-24-05.html
+;;QUERY;HTML;https://4canoesportal.org/focused/
+;;QUERY;HTML;https://4canoes.com/focused-education-resources

--- a/4cn/test/4cn.2026-08-17.csv
+++ b/4cn/test/4cn.2026-08-17.csv
@@ -1,0 +1,9 @@
+out-title_id;out-unitid;out-rtype;out-mime;in-url
+BrandNewTitle;BrandNewTitle_2026-08-17_09-00-00;BOOK;HTML;https://4canoesportal.org/shelf/BrandNewTitle/BrandNewTitle_2026-08-17_09-00-00.html
+josefasstory;JosefasStory_2024-11-15_20-01-13;BOOK;HTML;https://4canoesportal.org/shelf/josefasstory/JosefasStory_2024-11-15_20-01-13.html
+FirstWordsK6EducatorGuide;FirstWordsK6EducatorGuideMastersK6_2023-10-23_16-34-40;BOOK;HTML;https://4canoesportal.org/shelf/FirstWordsK6EducatorGuide/FirstWordsK6EducatorGuideMastersK6_2023-10-23_16-34-40.html
+Vol1EducatorGuide;Vol1EducatorGuide_2022-11-28_16-39-25;BOOK;HTML;https://4canoesportal.org/shelf/Vol1EducatorGuide/Vol1EducatorGuide_2022-11-28_16-39-25.html
+MikmaqSpecialEdition;MikmaqSpecialEdition_2025-11-19_15-39-21;BOOK;HTML;https://4canoesportal.org/shelf2/MikmaqSpecialEdition/MikmaqSpecialEdition_2025-11-19_15-39-21.html
+Haida;TheHaidaofHaidaGwaii_2022-11-07_15-24-05;BOOK;HTML;https://4canoesportal.org/shelf/Haida/TheHaidaofHaidaGwaii_2022-11-07_15-24-05.html
+;;QUERY;HTML;https://4canoesportal.org/focused/
+;;QUERY;HTML;https://4canoes.com/focused-education-resources


### PR DESCRIPTION
The BOOK branch never matched /shelf2/ paths or directories containing digits,
so those accesses returned an empty result with no rtype, mime or unitid.

shelf\d* now matches numbered shelves, the directory pattern allows digits, and
the directory is captured and exposed as title_id. unitid is unchanged.

title_id is set in anticipation of a pkb for this platform. pkb remains false
and no knowledge base file is included here.

Test files regenerated through AnalogIST, manifest version bumped to match.
13 passing.