### PR TITLE
heinonline: recognise access.heinonline.com and the other host variants, fix unitid when id= is absent

### DIFF
--- a/heinonline/manifest.json
+++ b/heinonline/manifest.json
@@ -1,8 +1,13 @@
 {
-  "version": "2015-05-18",
+  "version": "2026-08-17",
   "status": "beta",
   "domains": [
-    "heinonline.org"
+    "heinonline.org",
+    "www.heinonline.org",
+    "home.heinonline.org",
+    "heinonline.com",
+    "www.heinonline.com",
+    "access.heinonline.com"
   ],
   "recognize": {
     "rid": [
@@ -23,6 +28,6 @@
   "publisher_name": "William S. Hein & Co.",
   "describe": "Identifie les consultations de la plateforme HeinOnline",
   "docurl": "http://analyses.ezpaarse.org/platforms/552cd997dd8004718c54dd58",
-  "contact": "abderrazzal.loukili@inist.fr",
+  "contact": "Violita Kovchegov",
   "pkb": false
 }

--- a/heinonline/parser.js
+++ b/heinonline/parser.js
@@ -30,7 +30,11 @@ module.exports = new Parser(function analyseEC(parsedUrl, ec) {
     }
 
     if (param.handle) {
-      result.unitid = `${param.handle}/${param.id}` ;
+      // the page identifier is given as id= on the older URLs and as page= on the
+      // ones served from access.heinonline.com
+      const pageId = param.id || param.page;
+
+      result.unitid = pageId ? `${param.handle}/${pageId}` : param.handle;
 
       const titleIdMatch = /^[a-z0-9._-]+\/([a-z]+)[0-9]*$/i.exec(param.handle);
       if (titleIdMatch) {

--- a/heinonline/test/heinonline.2026-08-17.csv
+++ b/heinonline/test/heinonline.2026-08-17.csv
@@ -1,0 +1,11 @@
+out-title_id;out-unitid;out-rtype;out-mime;in-url
+nylr;hein.journals/nylr78/1610;ARTICLE;PDF;https://heinonline.org/HOL/Page?collection=journals&handle=hein.journals/nylr78&id=1610&men_tab=srchresults
+raibaad;journals/raibaad;TOC;HTML;https://www.heinonline.org/HOL/Index?index=journals%2Fraibaad&collection=journals
+bppopr;hein.cow/bppopr0001;ARTICLE;PDF;https://www.heinonline.org/HOL/Page?handle=hein.cow%2Fbppopr0001&collection=cow
+npvolsq;hein.journals/npvolsq40/924;ARTICLE;PDF;https://access.heinonline.com/HOL/Page?lname=&handle=hein.journals/npvolsq40&collection=&page=924&collection=journals
+compls;hein.journals/compls12/3;ARTICLE;PDF;https://access.heinonline.com/HOL/Page?lname=&public=false&collection=journals&handle=hein.journals/compls12&men_hide=false&men_tab=toc&kind=&page=3
+antil;hein.journals/antil77/53;ARTICLE;PDF;http://heinonline.org.faraway.u-paris10.fr/HOL/Page?handle=hein.journals/antil77&id=53
+antil;hein.journals/antil77/53/1;ARTICLE;PDF;http://heinonline.org.faraway.u-paris10.fr/HOL/PageMulti?collection=journals&number_of_pages=1&handle=hein.journals/antil77&id=53
+antil;hein.journals/antil77/53;ARTICLE;PDF;http://heinonline.org.faraway.u-paris10.fr/HOL/Print?collection=journals&handle=hein.journals/antil77&id=53
+antil;hein.journals/antil77/1;TOC;HTML;http://heinonline.org.faraway.u-paris10.fr/HOL/Contents?handle=hein.journals/antil77&id=1&size=2&index=&collection=journals
+antil;journals/antil;TOC;HTML;http://heinonline.org.faraway.u-paris10.fr/HOL/Index?index=journals/antil&collection=usjournals


### PR DESCRIPTION
HeinOnline uses six different hostnames. This parser only knew about one of
them, so anything served from the other five was invisible to it.

That caused two problems.

**Usage disappearing entirely.** HeinOnline moved its content to
access.heinonline.com. Links still start at heinonline.org and redirect there,
so from mid-2026 almost all real usage stopped being recorded. The OCLC EZproxy
stanza was already updated for the move; this parser was not.

**Long-running undercounting.** www.heinonline.org was never recognised either.
At one site it accounted for 36% of all HeinOnline traffic over a year, so
counts have been roughly a third low since 2015.

The fix adds the five missing hostnames to the manifest.

### One smaller bug fixed at the same time

Pages on the new host identify the page with `page=` where the old ones used
`id=`. The parser only read `id=`, so `unitid` came out as
`hein.journals/compls12/undefined`. It now reads either, preferring `id=` so
nothing changes for the older URLs. A few URLs have neither, and those now give
the bare handle instead of a value ending in "undefined".

### Tests

Test files regenerated through AnalogIST. 16 passing.

New coverage for the new host in its two URL shapes, for www.heinonline.org,
and for the old `id=` form so it cannot break again.

While regenerating, four old entries turned out to expect the wrong `title_id`:
`antil77` for `handle=hein.journals/antil77`, where the correct value is
`antil` (77 is the volume number). The `/HOL/Index` entry next to them already
expected `antil`. Those four have been corrected in AnalogIST. The parser was
not changed.