### PR TITLE
Vlex 2026 08 18: recognize server-visible paths, add missing domains

### DIFF
--- a/vlex/manifest.json
+++ b/vlex/manifest.json
@@ -7,8 +7,10 @@
   "docurl": "http://analyses.ezpaarse.org/platforms/5c0a3384204fd76c95fb90d3",
   "domains": [
     "app.vlex.com",
-    "justis.vlex.com"
+    "justis.vlex.com",
+    "vlex.com",
+    "2019.vlex.com"
   ],
-  "version": "2021-11-23",
+  "version": "2026-08-18",
   "status": "beta"
 }

--- a/vlex/parser.js
+++ b/vlex/parser.js
@@ -14,25 +14,56 @@ const URL    = require('url');
 module.exports = new Parser(function analyseEC(parsedUrl, ec) {
   let result = {};
 
-  const hash = parsedUrl.hash.replace('#', '');
-  const hashedUrl = URL.parse(hash, true);
-
   let match;
 
+  // Legacy fragment form, kept so existing behaviour is preserved.
+  // Fragments are client-side and never reach a server, so this branch
+  // does not fire on proxy logs. See the path handling below.
+  const hash = (parsedUrl.hash || '').replace('#', '');
 
-  if ((match = /^search\/([a-z:]+)\/([a-z]+)$/i.exec(hashedUrl.pathname)) !== null) {
-    // https://app.vlex.com/#search/jurisdiction:CL/COVID
-    result.rtype    = 'SEARCH';
-    result.mime     = 'HTML';
-    result.search_term = match[2];
+  if (hash) {
+    const hashedUrl = URL.parse(hash, true);
 
-  } else if ((match = /^([a-z]+)?\/vid\/([0-9]+)$/i.exec(hashedUrl.pathname)) !== null) {
-    // https://app.vlex.com/#/vid/877960841
-    // https://app.vlex.com/#WW/vid/877911364
+    if ((match = /^search\/([a-z:]+)\/([a-z]+)$/i.exec(hashedUrl.pathname)) !== null) {
+      // https://app.vlex.com/#search/jurisdiction:CL/COVID
+      result.rtype    = 'SEARCH';
+      result.mime     = 'HTML';
+      result.search_term = match[2];
+
+      return result;
+
+    } else if ((match = /^([a-z]+)?\/vid\/([0-9]+)$/i.exec(hashedUrl.pathname)) !== null) {
+      // https://app.vlex.com/#/vid/877960841
+      // https://app.vlex.com/#WW/vid/877911364
+      result.rtype    = 'ARTICLE';
+      result.mime     = 'HTML';
+      result.unitid   = match[2];
+
+      return result;
+    }
+  }
+
+  // Server-visible paths, which is what appears in proxy logs.
+  // Shape: /search/<facets>/<terms>[/pN]/vid/<id>
+  const path = parsedUrl.pathname || '/';
+
+  if ((match = /\/vid\/([0-9]+)$/i.exec(path)) !== null) {
+    // https://app.vlex.com/search/jurisdiction:AR+content_type:4/libertad+de+expresion/vid/729674889
+    // https://app.vlex.com/search/jurisdiction:AR+content_type:2/dano+moral/p2/vid/945610102
     result.rtype    = 'ARTICLE';
     result.mime     = 'HTML';
-    result.unitid   = match[2];
+    result.unitid   = match[1];
+
+  } else if (/^\/search\//i.test(path)) {
+    // https://app.vlex.com/search/jurisdiction:AR,XM/13679%2F2025-CR
+    result.rtype    = 'SEARCH';
+    result.mime     = 'HTML';
   }
+
+  // Everything else is deliberately left unrecognized so it is not counted
+  // as content: the bare application root (a single page app landing page),
+  // /account/login_ip (an IP recognition handshake, not an access) and
+  // static assets.
 
   return result;
 });

--- a/vlex/test/vlex.2026-08-18.csv
+++ b/vlex/test/vlex.2026-08-18.csv
@@ -1,0 +1,6 @@
+out-unitid;out-rtype;out-mime;in-url
+;SEARCH;HTML;https://app.vlex.com/search/jurisdiction:AR,XM/13679%2F2025-CR
+729674889;ARTICLE;HTML;https://app.vlex.com/search/jurisdiction:AR+content_type:4/libertad+de+expresion+y+discurso+de+odio/vid/729674889
+877911364;ARTICLE;HTML;https://app.vlex.com/#WW/vid/877911364
+877960841;ARTICLE;HTML;https://app.vlex.com/#/vid/877960841
+COVID;SEARCH;HTML;https://app.vlex.com/#search/jurisdiction:CL/COVID

--- a/vlex/test/vlex.2026-08-18.csv
+++ b/vlex/test/vlex.2026-08-18.csv
@@ -3,4 +3,3 @@ out-unitid;out-rtype;out-mime;in-url
 729674889;ARTICLE;HTML;https://app.vlex.com/search/jurisdiction:AR+content_type:4/libertad+de+expresion+y+discurso+de+odio/vid/729674889
 877911364;ARTICLE;HTML;https://app.vlex.com/#WW/vid/877911364
 877960841;ARTICLE;HTML;https://app.vlex.com/#/vid/877960841
-COVID;SEARCH;HTML;https://app.vlex.com/#search/jurisdiction:CL/COVID


### PR DESCRIPTION
The parser only read the URL fragment (#). Fragments are client-side and never reach a server, so the parser produced no result for any URL appearing in proxy logs. parsedUrl.hash is also null when there is no fragment, so the first line threw on every record.

vLex serves the same content on ordinary paths, in the shape /search/<facets>/<terms>[/pN]/vid/<id>, and those do reach the server. This adds a branch that reads parsedUrl.pathname:

a path ending in /vid/<id> gets rtype: ARTICLE and unitid
a path beginning /search/ gets rtype: SEARCH

The bare application root, /account/login_ip and static assets are deliberately left unrecognized, so a single page app landing and an IP recognition handshake are not counted as content.

The existing fragment branch is kept unchanged, now guarded against a null hash and returning early, so the three existing test cases pass exactly as before.

manifest.json adds vlex.com and 2019.vlex.com, both observed serving vLex traffic and neither previously claimed.