### PR TITLE
Ft 2026 09 10

### DIFF
--- a/ft/manifest.json
+++ b/ft/manifest.json
@@ -1,5 +1,5 @@
 {
-  "version": "2016-11-22",
+  "version": "2026-09-10",
   "status": "beta",
   "domains": [
     "www.ft.com",

--- a/ft/parser.js
+++ b/ft/parser.js
@@ -15,7 +15,13 @@ module.exports = new Parser(function analyseEC(parsedUrl, ec) {
   let path   = parsedUrl.pathname;
   let match;
 
-  if ((match = /^\/cms\/([a-z]+)\/([0-9]+)\/([0-9a-z-]+).html$/i.exec(path)) !== null) {
+  if ((match = /^\/content\/([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})$/i.exec(path)) !== null) {
+    ///content/fd8a1648-62ce-49f4-ab2d-c22c9e0d1802
+    result.rtype    = 'ARTICLE';
+    result.mime     = 'HTML';
+    result.unitid   = match[1];
+
+  } else if ((match = /^\/cms\/([a-z]+)\/([0-9]+)\/([0-9a-z-]+).html$/i.exec(path)) !== null) {
     ///cms/s/0/0b4a4790-6454-11e6-8310-ecf0bddad227.html#axzz4HgTPkTq0
     result.rtype    = 'ARTICLE';
     result.mime     = 'HTML';

--- a/ft/test/ft.2026-09-10.csv
+++ b/ft/test/ft.2026-09-10.csv
@@ -1,0 +1,2 @@
+out-title_id;out-unitid;out-rtype;out-mime;in-url
+;fd8a1648-62ce-49f4-ab2d-c22c9e0d1802;ARTICLE;HTML;https://www.ft.com/content/fd8a1648-62ce-49f4-ab2d-c22c9e0d1802


### PR DESCRIPTION
The Financial Times parser did not recognize FT's current article URLs.

Its article rule matches `/cms/s/0/<uuid>.html`, a format FT stopped using around 2018. 

Nothing in the parser matched that, so article views were not being counted.  This adds a rule for it.

In twelve months of logs at one subscribing institution there were 276 of these requests across 128 different articles, and none were recognized.